### PR TITLE
Add default color for Python docstrings, colored as strings

### DIFF
--- a/templates/common.p.py
+++ b/templates/common.p.py
@@ -89,7 +89,7 @@ def parseScheme(colors):
 # #else
                 'size': 11,
 # #endif
-                
+
                 'useFixed': 1,
                 'bold': 0,
                 'lineSpacing': 2
@@ -277,6 +277,16 @@ def parseScheme(colors):
                 },
                 'commentdockeyworderror': {
                     'fore': colors["red"]
+                }
+            },
+            'Python': {
+                'docstrings': {
+                    'fore': colors["green"]
+                }
+            },
+            'Python3': {
+                'docstrings': {
+                    'fore': colors["green"]
                 }
             }
         },


### PR DESCRIPTION
Related:
https://github.com/Komodo/KomodoEdit/commit/38a3b29e8de8cc28c9d8283bb3f342d88008fb6a
https://github.com/Komodo/KomodoEdit/pull/614
